### PR TITLE
Remove legacy Slack references

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,12 +7,6 @@
 		    <a href="/#/README?id=guides">Guides</a>
 		</div>
 		<div class="footer-links">
-		    <h4>Channel</h4>
-		    <a target="_blank" href="https://godaddy-oss-slack.herokuapp.com">Slack</a>
-		    <!--                <a  target="_blank" href="https://twitter.com/gasketjs">Twitter</a>-->
-		    <a target="_blank" href="https://stackoverflow.com/questions/tagged/gasket">Stack Overflow</a>
-		</div>
-		<div class="footer-links">
 		    <h4>Contribute</h4>
 		    <a href="htts://gasket.dev/#/CONTRIBUTING">Guidelines</a>
 		    <a target="_blank" href="https://github.com/godaddy/gasket/">Github</a>


### PR DESCRIPTION
Contributions and questions should now be handled in GitHub Issues and Discussions